### PR TITLE
typo fix: const -> class

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import GradientButton from 'react-linear-gradient-button';
 
-const Basic extends Component {
+class Basic extends Component {
   render() {
     return <GradientButton content="BUTTON" />;
   }


### PR DESCRIPTION
It should be `class` here